### PR TITLE
Catch PDO exception the right way

### DIFF
--- a/application/Core/Model.php
+++ b/application/Core/Model.php
@@ -18,7 +18,7 @@ class Model
     {
         try {
             self::openDatabaseConnection();
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             exit('Database connection could not be established.');
         }
     }


### PR DESCRIPTION
When the dabase server is down the exception was not caught due to namespaces
ref: http://php.net/manual/es/language.exceptions.php#97963