### PR TITLE
Fix for #13: error page replaces page, instead of redirecting the user to a new page

### DIFF
--- a/application/Core/Application.php
+++ b/application/Core/Application.php
@@ -54,12 +54,12 @@ class Application
                     $this->url_controller->index();
                 } else {
                     $page = new \Mini\Controller\ErrorController();
-                    $page->errorPage();
+                    $page->index();
                 }
             }
         } else {
             $page = new \Mini\Controller\ErrorController();
-            $page->errorPage();
+            $page->index();
         }
     }
 

--- a/application/Core/Application.php
+++ b/application/Core/Application.php
@@ -53,11 +53,13 @@ class Application
                     // no action defined: call the default index() method of a selected controller
                     $this->url_controller->index();
                 } else {
-                    header('location: ' . URL . 'error');
+                    $page = new \Mini\Controller\ErrorController();
+                    $page->errorPage();
                 }
             }
         } else {
-            header('location: ' . URL . 'error');
+            $page = new \Mini\Controller\ErrorController();
+            $page->errorPage();
         }
     }
 


### PR DESCRIPTION
Fixes #13 and allows the user to stay at the URL he/she attempted to hit. This is especially handy if you're having database issues and want to hit refresh to check it again.