### PR TITLE
Fix for #15: Fixed bug for editSong throwing error when song_id doesn't exist

### DIFF
--- a/application/Controller/SongsController.php
+++ b/application/Controller/SongsController.php
@@ -97,11 +97,18 @@ class SongsController
 
             // in a real application we would also check if this db entry exists and therefore show the result or
             // redirect the user to an error page or similar
-
-            // load views. within the views we can echo out $song easily
-            require APP . 'view/_templates/header.php';
-            require APP . 'view/songs/edit.php';
-            require APP . 'view/_templates/footer.php';
+            if (!$song)
+            {
+                $page = new \Mini\Controller\ErrorController();
+                $page->index();
+            }
+            else
+            {
+                // load views. within the views we can echo out $song easily
+                require APP . 'view/_templates/header.php';
+                require APP . 'view/songs/edit.php';
+                require APP . 'view/_templates/footer.php';
+            }
         } else {
             // redirect user to songs index page (as we don't have a song_id)
             header('location: ' . URL . 'songs/index');

--- a/application/Controller/SongsController.php
+++ b/application/Controller/SongsController.php
@@ -95,15 +95,11 @@ class SongsController
             // do getSong() in model/model.php
             $song = $Song->getSong($song_id);
 
-            // in a real application we would also check if this db entry exists and therefore show the result or
-            // redirect the user to an error page or similar
-            if (!$song)
-            {
+            // If the song wasn't found, then it would have returned false, and we need to display the error page
+            if ($song === false) {
                 $page = new \Mini\Controller\ErrorController();
                 $page->index();
-            }
-            else
-            {
+            } else {
                 // load views. within the views we can echo out $song easily
                 require APP . 'view/_templates/header.php';
                 require APP . 'view/songs/edit.php';

--- a/application/Model/Song.php
+++ b/application/Model/Song.php
@@ -89,7 +89,7 @@ class Song extends Model
         $query->execute($parameters);
 
         // fetch() is the PDO method that get exactly one result
-        return $query->fetch();
+        return ($query->rowcount() ? $query->fetch() : false);
     }
 
     /**


### PR DESCRIPTION
For #15:

If a song doesn't exist in the database, the application will throw a PHP error. To fix this, I check for rowCount() of the getSong method, and, if it's zero (i.e. that song_id doesn't exist in the database), I return false. I then check the status of that in the SongsController editSong method, and display either the edit page, or the error page depending.

This can be changed by the user in a variety of ways.

Understanding this page probably doesn't matter much to users of this framework, a bug is a bug.

@panique this is a rudimentary solution, and certainly not a hyper elegant one. If there's a better solution for it, please feel free to change it. This uses the error solution from PR #41, to display the error page in-place, instead of redirecting to the error page; this can be changed easily, however.