### PR TITLE
Modernize footer.php

### DIFF
--- a/application/view/_templates/footer.php
+++ b/application/view/_templates/footer.php
@@ -6,14 +6,14 @@
 
     <!-- jQuery, loaded in the recommended protocol-less way -->
     <!-- more http://www.paulirish.com/2010/the-protocol-relative-url/ -->
-    <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-3.3.1.min.js"></script>
 
     <!-- define the project's URL (to make AJAX calls possible, even when using this in sub-folders etc) -->
     <script>
-        var url = "<?php echo URL; ?>";
+        var URL = "<?=URL?>";
     </script>
 
     <!-- our JavaScript -->
-    <script src="<?php echo URL; ?>js/application.js"></script>
+    <script src="<?=URL?>js/application.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Updated jQuery version (1.11.1 was from May 2014), capitalized Javascript "url" variable to be more in line with the PHP constant, and updated ```<?php echo URL; ?>``` to the shorthand ```<?=URL?>``` that is standard as of PHP 5.4