### PR TITLE
♻️: Refactoring the <view> function

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ the header, footer and the example_one.php page (in views/home/). By intention a
 public function exampleOne()
 {
     // load view
-    require APP . 'views/_templates/header.php';
-    require APP . 'views/home/example_one.php';
-    require APP . 'views/_templates/footer.php';
+    view('views/_templates/header');
+    view('views/home/example_one');
+    view('views/_templates/footer');
 }
 ```  
 
@@ -218,9 +218,9 @@ class SongsController
         $amount_of_songs = $Song->getAmountOfSongs();
 
         // load view. within the view files we can echo out $songs and $amount_of_songs easily
-        require APP . 'views/_templates/header.php';
-        require APP . 'views/songs/index.php';
-        require APP . 'views/_templates/footer.php';
+        view('views/_templates/header');
+        view('views/songs/index');
+        view('views/_templates/footer');
     }
 }
 ```
@@ -266,6 +266,10 @@ Please commit into the develop branch (which holds the in-development version), 
 (which holds the tested and stable version).
 
 ## Changelog
+
+**September 2021**
+
+- [iamrameffort] ♻️: Refactoring the `view` function and removing the extension from the view files in the controllers.
 
 **August 2016**
 

--- a/application/Controller/ErrorController.php
+++ b/application/Controller/ErrorController.php
@@ -20,8 +20,8 @@ class ErrorController
     public function index()
     {
         // load views
-        view('_templates/header.php');
-        view('error/index.php');
-        view('_templates/footer.php');
+        view('_templates/header');
+        view('error/index');
+        view('_templates/footer');
     }
 }

--- a/application/Controller/HomeController.php
+++ b/application/Controller/HomeController.php
@@ -20,9 +20,9 @@ class HomeController
     public function index()
     {
         // load views
-        view('_templates/header.php');
-        view('home/index.php');
-        view('_templates/footer.php');
+        view('_templates/header');
+        view('home/index');
+        view('_templates/footer');
 
     }
 
@@ -34,9 +34,9 @@ class HomeController
     public function exampleOne()
     {
         // load views
-        view('_templates/header.php');
-        view('home/example_one.php');
-        view('_templates/footer.php');
+        view('_templates/header');
+        view('home/example_one');
+        view('_templates/footer');
     }
 
     /**
@@ -47,8 +47,8 @@ class HomeController
     public function exampleTwo()
     {
         // load views
-        view('_templates/header.php');
-        view('home/example_two.php');
-        view('_templates/footer.php');
+        view('_templates/header');
+        view('home/example_two');
+        view('_templates/footer');
     }
 }

--- a/application/Controller/SongsController.php
+++ b/application/Controller/SongsController.php
@@ -31,9 +31,9 @@ class SongsController
         $amount_of_songs = $Song->getAmountOfSongs();
 
         // load views. within the views we can echo out $songs and $amount_of_songs easily
-        view('_templates/header.php');
-        view('songs/index.php', ["songs" => $songs]);
-        view('_templates/footer.php');
+        view('_templates/header');
+        view('songs/index', ["songs" => $songs]);
+        view('_templates/footer');
     }
 
     /**
@@ -101,9 +101,9 @@ class SongsController
                 $page->index();
             } else {
                 // load views. within the views we can echo out $song easily
-                view('_templates/header.php');
-                view('songs/edit.php', ["song" => $song]);
-                view('_templates/footer.php');
+                view('_templates/header');
+                view('songs/edit', ["song" => $song]);
+                view('_templates/footer');
             }
         } else {
             // redirect user to songs index page (as we don't have a song_id)

--- a/application/Core/CoreFunctions.php
+++ b/application/Core/CoreFunctions.php
@@ -2,14 +2,11 @@
 
 namespace Mini\Controller;
 
-function view($path, $data = [])
+function view(string $file, array $data = [])
 {
-    foreach ($data as $k => $v) {
-        $$k = $v;
-    }
-    require APP . "view/{$path}";
+    extract($data);
+    require sprintf('%sview/%s.php', APP, $file);
 }
-
 
 function redirect($path) {
     header('location: ' . URL . $path);

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "f0a852d514836f66a2b863f641142346",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}


### PR DESCRIPTION
Refactoring of the <view> function to a simpler code, allowing the removal of the file extension from the view in the controllers.

### Usage

Before:
```php
public function index()
{
    view('_templates/header.php');
    view('home/index.php');
    view('_templates/footer.php');
}
```

After:
```php
public function index()
{
    view('_templates/header');
    view('home/index');
    view('_templates/footer');
}
```