### PR TITLE
Update to PHP 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ of the original MINI, made by [JaoNoctus](https://github.com/JaoNoctus). Big tha
 
 ## Requirements (but it's auto-installed)
 
-- PHP 8
+- PHP 8.2 and higher
 - MySQL
 - basic knowledge of Composer for sure
 - for auto-installation: VirtualBox, Vagrant

--- a/application/Controller/ErrorController.php
+++ b/application/Controller/ErrorController.php
@@ -17,7 +17,7 @@ class ErrorController
      * PAGE: index
      * This method handles the error page that will be shown when a page is not found
      */
-    public function index()
+    public function index(): void
     {
         // load views
         require APP . 'view/_templates/header.php';

--- a/application/Controller/HomeController.php
+++ b/application/Controller/HomeController.php
@@ -17,7 +17,7 @@ class HomeController
      * PAGE: index
      * This method handles what happens when you move to http://yourproject/home/index (which is the default page btw)
      */
-    public function index()
+    public function index(): void
     {
         // load views
         require APP . 'view/_templates/header.php';
@@ -30,7 +30,7 @@ class HomeController
      * This method handles what happens when you move to http://yourproject/home/exampleone
      * The camelCase writing is just for better readability. The method name is case-insensitive.
      */
-    public function exampleOne()
+    public function exampleOne(): void
     {
         // load views
         require APP . 'view/_templates/header.php';
@@ -43,7 +43,7 @@ class HomeController
      * This method handles what happens when you move to http://yourproject/home/exampletwo
      * The camelCase writing is just for better readability. The method name is case-insensitive.
      */
-    public function exampleTwo()
+    public function exampleTwo(): void
     {
         // load views
         require APP . 'view/_templates/header.php';

--- a/application/Controller/SongsController.php
+++ b/application/Controller/SongsController.php
@@ -22,7 +22,7 @@ class SongsController
      * PAGE: index
      * This method handles what happens when you move to http://yourproject/songs/index
      */
-    public function index()
+    public function index(): void
     {
         // Instance new Model (Song)
         $Song = new Song();
@@ -44,7 +44,7 @@ class SongsController
      * the user back to songs/index via the last line: header(...)
      * This is an example of how to handle a POST request.
      */
-    public function addSong()
+    public function addSong(): void
     {
         // if we have POST data to create a new song entry
         if (isset($_POST["submit_add_song"])) {
@@ -65,9 +65,9 @@ class SongsController
      * directs the user after the click. This method handles all the data from the GET request (in the URL!) and then
      * redirects the user back to songs/index via the last line: header(...)
      * This is an example of how to handle a GET request.
-     * @param int $song_id Id of the to-delete song
+     * @param ?int $song_id Id of the to-delete song
      */
-    public function deleteSong($song_id)
+    public function deleteSong(?int $song_id): void
     {
         // if we have an id of a song that should be deleted
         if (isset($song_id)) {
@@ -84,9 +84,9 @@ class SongsController
      /**
      * ACTION: editSong
      * This method handles what happens when you move to http://yourproject/songs/editsong
-     * @param int $song_id Id of the to-edit song
+     * @param ?int $song_id Id of the to-edit song
      */
-    public function editSong($song_id)
+    public function editSong(?int $song_id): void
     {
         // if we have an id of a song that should be edited
         if (isset($song_id)) {
@@ -116,7 +116,7 @@ class SongsController
      * the user back to songs/index via the last line: header(...)
      * This is an example of how to handle a POST request.
      */
-    public function updateSong()
+    public function updateSong(): void
     {
         // if we have POST data to create a new song entry
         if (isset($_POST["submit_update_song"])) {
@@ -134,7 +134,7 @@ class SongsController
      * AJAX-ACTION: ajaxGetStats
      * TODO documentation
      */
-    public function ajaxGetStats()
+    public function ajaxGetStats(): void
     {
         // Instance new Model (Song)
         $Song = new Song();

--- a/application/Core/Application.php
+++ b/application/Core/Application.php
@@ -4,14 +4,14 @@ namespace Mini\Core;
 
 class Application
 {
-    /** @var null The controller */
-    private $url_controller = null;
+    /** @var ?object The controller */
+    private ?object $url_controller = null;
 
-    /** @var null The method (of the above controller), often also named "action" */
-    private $url_action = null;
+    /** @var ?string The method (of the above controller), often also named "action" */
+    private ?string $url_action = null;
 
     /** @var array URL parameters */
-    private $url_params = array();
+    private array $url_params = [];
 
     /**
      * "Start" the application:
@@ -63,7 +63,7 @@ class Application
     /**
      * Get and split the URL
      */
-    private function splitUrl()
+    private function splitUrl(): void
     {
         if (isset($_GET['url'])) {
 
@@ -75,8 +75,8 @@ class Application
             // Put URL parts into according properties
             // By the way, the syntax here is just a short form of if/else, called "Ternary Operators"
             // @see http://davidwalsh.name/php-shorthand-if-else-ternary-operators
-            $this->url_controller = isset($url[0]) ? $url[0] : null;
-            $this->url_action = isset($url[1]) ? $url[1] : null;
+            $this->url_controller = $url[0] ?? null;
+            $this->url_action = $url[1] ?? null;
 
             // Remove controller and action from the split URL
             unset($url[0], $url[1]);

--- a/application/Core/Model.php
+++ b/application/Core/Model.php
@@ -7,9 +7,9 @@ use PDO;
 class Model
 {
     /**
-     * @var null Database Connection
+     * @var ?PDO Database Connection
      */
-    public $db = null;
+    public ?PDO $db = null;
 
     /**
      * Whenever model is created, open a database connection.
@@ -26,7 +26,7 @@ class Model
     /**
      * Open the database connection with the credentials from application/config/config.php
      */
-    private function openDatabaseConnection()
+    private function openDatabaseConnection(): void
     {
         // set the (optional) options of the PDO connection. in this case, we set the fetch mode to
         // "objects", which means all results will be objects, like this: $result->user_name !

--- a/application/Model/Song.php
+++ b/application/Model/Song.php
@@ -19,7 +19,7 @@ class Song extends Model
     /**
      * Get all songs from database
      */
-    public function getAllSongs()
+    public function getAllSongs(): false|array
     {
         $sql = "SELECT id, artist, track, link FROM song";
         $query = $this->db->prepare($sql);
@@ -43,7 +43,7 @@ class Song extends Model
      * @param string $track Track
      * @param string $link Link
      */
-    public function addSong($artist, $track, $link)
+    public function addSong(string $artist, string $track, string $link): void
     {
         $sql = "INSERT INTO song (artist, track, link) VALUES (:artist, :track, :link)";
         $query = $this->db->prepare($sql);
@@ -61,7 +61,7 @@ class Song extends Model
      * add/update/delete stuff!
      * @param int $song_id Id of song
      */
-    public function deleteSong($song_id)
+    public function deleteSong(int $song_id): void
     {
         $sql = "DELETE FROM song WHERE id = :song_id";
         $query = $this->db->prepare($sql);
@@ -77,7 +77,7 @@ class Song extends Model
      * Get a song from database
      * @param integer $song_id
      */
-    public function getSong($song_id)
+    public function getSong(int $song_id): mixed
     {
         $sql = "SELECT id, artist, track, link FROM song WHERE id = :song_id LIMIT 1";
         $query = $this->db->prepare($sql);
@@ -104,7 +104,7 @@ class Song extends Model
      * @param string $link Link
      * @param int $song_id Id
      */
-    public function updateSong($artist, $track, $link, $song_id)
+    public function updateSong(string $artist, string $track, string $link, int $song_id): void
     {
         $sql = "UPDATE song SET artist = :artist, track = :track, link = :link WHERE id = :song_id";
         $query = $this->db->prepare($sql);
@@ -120,7 +120,7 @@ class Song extends Model
      * Get simple "stats". This is just a simple demo to show
      * how to use more than one model in a controller (see application/controller/songs.php for more)
      */
-    public function getAmountOfSongs()
+    public function getAmountOfSongs(): ?int
     {
         $sql = "SELECT COUNT(id) AS amount_of_songs FROM song";
         $query = $this->db->prepare($sql);

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,7 @@ sudo apt-get update
 sudo apt-get -y upgrade
 
 # php
-sudo apt install -y php8.1-fpm
+sudo apt install -y php8.2-fpm
 # php modules
 sudo apt install -y php-xml
 sudo apt install -y php-mbstring
@@ -25,7 +25,7 @@ sudo systemctl restart nginx
 sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $PASSWORD"
 sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $PASSWORD"
 sudo apt-get install -y mysql-server
-sudo apt-get install -y php8.1-mysql
+sudo apt-get install -y php8.2-mysql
 
 # run SQL statements
 sudo mysql -h "localhost" -u "root" "-p${PASSWORD}" < "/var/www/html/_install/mysql/01-create-database.sql"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "panique/mini3",
     "minimum-stability": "dev",
-    "require": {},
+    "require": {
+        "php": ">=8.2"
+    },
     "autoload":
     {
         "psr-4":


### PR DESCRIPTION
PHP 8.1 is not [actively supported anymore](https://www.php.net/supported-versions.php). This pull requests aims to update the project to PHP 8.2.

- added PHP 8.2 as a requirement to the composer.json (best practice)
- added a note to the README to be more precise about the required PHP version
- added type hints to the core, controllers and models (best practice)
- updated `bootstrap.sh` (@panique could you review that? I'm not using Vagrant)

### Some questions I had while updating

- should we add `ext-pdo` to the composer.json, since we are providing PDO models?
- should we switch to `const ...` instead of `define(...)` in the `application/config/config.php` and `public/index.php`? 