### PR TITLE
Fix Missing Namespace

### DIFF
--- a/application/Core/Helper.php
+++ b/application/Core/Helper.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Mini\Core;
+
+class Helper
+{
+    /**
+     * debugPDO
+     *
+     * Shows the emulated SQL query in a PDO statement. What it does is just extremely simple, but powerful:
+     * It combines the raw query and the placeholders. For sure not really perfect (as PDO is more complex than just
+     * combining raw query and arguments), but it does the job.
+     *
+     * @author Panique
+     * @param string $raw_sql
+     * @param array $parameters
+     * @return string
+     */
+    static public function debugPDO($raw_sql, $parameters) {
+
+        $keys = array();
+        $values = $parameters;
+
+        foreach ($parameters as $key => $value) {
+
+            // check if named parameters (':param') or anonymous parameters ('?') are used
+            if (is_string($key)) {
+                $keys[] = '/' . $key . '/';
+            } else {
+                $keys[] = '/[?]/';
+            }
+
+            // bring parameter into human-readable format
+            if (is_string($value)) {
+                $values[$key] = "'" . $value . "'";
+            } elseif (is_array($value)) {
+                $values[$key] = implode(',', $value);
+            } elseif (is_null($value)) {
+                $values[$key] = 'NULL';
+            }
+        }
+
+        /*
+        echo "<br> [DEBUG] Keys:<pre>";
+        print_r($keys);
+
+        echo "\n[DEBUG] Values: ";
+        print_r($values);
+        echo "</pre>";
+        */
+
+        $raw_sql = preg_replace($keys, $values, $raw_sql, 1, $count);
+
+        return $raw_sql;
+    }
+
+}

--- a/application/Model/Song.php
+++ b/application/Model/Song.php
@@ -50,7 +50,7 @@ class Song extends Model
         $parameters = array(':artist' => $artist, ':track' => $track, ':link' => $link);
 
         // useful for debugging: you can see the SQL behind above construction by using:
-        // echo '[ PDO DEBUG ]: ' . Helper::debugPDO($sql, $parameters);  exit();
+        // echo '[ PDO DEBUG ]: ' . \Mini\Core\Helper::debugPDO($sql, $parameters);  exit();
 
         $query->execute($parameters);
     }


### PR DESCRIPTION
fix #55 

`application\Libs\Helper.php` was deleted in the meantime, but never re-added. Not sure what @panique plan is there, but for now I reversed the removal and moved it into the `Core` folder. 